### PR TITLE
Fixed value for Detailed Summary

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -215,7 +215,7 @@
       <select id="summary-style">
         <option value="bullet-points" selected>Bullet Points</option>
         <option value="summary">Summary</option>
-        <option value="detailed-summary">Detailed Summary</option>
+        <option value="detailed">Detailed Summary</option>
       </select>
     </div>
 


### PR DESCRIPTION
Set it to `detailed` instead of `detailed-summary` so that correct prompt is set at https://github.com/francescovaglia/kliply/blob/c8129a193517fcd99327564aad1e0c9458c27cbb/content.js#L186